### PR TITLE
Change requirements to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "autotradingkit"
+version = "0.1.0"
+description = "Auto Trading Kit"
+authors = [{ name = "Phan Cong" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.12, <3.14"
+dependencies = [
+    "pyside6 (==6.8.3)",
+    "colorthief (>=0.2.1,<0.3.0)",
+    "darkdetect (>=0.8.0,<0.9.0)",
+    "scipy (>=1.15.2,<2.0.0)",
+    "pillow (>=11.1.0,<12.0.0)",
+    "qasync (>=0.27.1,<0.28.0)",
+    "numpy (>=2.2.4,<3.0.0)",
+    "pyqtgraph (>=0.13.7,<0.14.0)",
+    "pandas (>=2.2.3,<3.0.0)",
+    "numba (>=0.61.0,<0.62.0)",
+    "ccxt (>=4.4.71,<5.0.0)",
+    "pyopengl (>=3.1.9,<4.0.0)",
+    "cython (>=3.0.12,<4.0.0)",
+    "pandas-datareader (>=0.10.0,<0.11.0)",
+    "arrow (>=1.3.0,<2.0.0)",
+    "setuptools (>=78.1.0,<79.0.0)",
+    "humanize (>=4.12.2,<5.0.0)",
+    "psygnal (>=0.12.0,<0.13.0)",
+    "click (>=8.1.8,<9.0.0)",
+    "pysidesix-frameless-window (>=0.5.1,<0.6.0)",
+    "websockets (>=15.0.1,<16.0.0)",
+]
+
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.group.dev.dependencies]
+pyside6-stubs = "^6.7.3.0"
+black = "^25.1.0"
+isort = "^6.0.1"
+
+[tool.poetry.group.win.dependencies]
+winloop = "0.1.8"
+pywin32 = "310"


### PR DESCRIPTION
Pyprojects is the new standard for python, and in my experience works way better than requirements, I would consider to use it in order to have better version managment.

https://peps.python.org/pep-0621/

In my case i use it with poetry but you can use it with other version managment tools.

also is good to separate dev dependences , windows one etc,  with the current requirements is not easy to install the project using poetry for instance.

I put an example here, not intended to be merged inmediatelly.